### PR TITLE
Make CURIEs a map, rather than an array

### DIFF
--- a/_includes/corevocabulary.md
+++ b/_includes/corevocabulary.md
@@ -3,6 +3,10 @@
 Despite its flexible and extensible nature, Hyper is a very simple
 media type with a small vocabulary.
 
+In Hyper, JSON arrays are used as sets, not ordered lists.  The
+order of a specified array should not be considered part of the
+conveyed information.
+
 #### h:head
 
 {% include propdefs/head.md %}

--- a/_includes/corevocabulary.md
+++ b/_includes/corevocabulary.md
@@ -3,10 +3,6 @@
 Despite its flexible and extensible nature, Hyper is a very simple
 media type with a small vocabulary.
 
-In Hyper, JSON arrays are used as sets, not ordered lists.  The
-order of a specified array should not be considered part of the
-conveyed information.
-
 #### h:head
 
 {% include propdefs/head.md %}

--- a/_includes/propdefs/head.md
+++ b/_includes/propdefs/head.md
@@ -34,7 +34,7 @@ definitions.
 
 ###### curies
 
-optional. List of
+optional. Map of
 [CURIEs](https://www.w3.org/TR/2010/NOTE-curie-20101216/), complying to the
 W3C definition. In Hyper, CURIEs can be used in values of "uri" fields or
 as any object's key's name. Please note that CURIEs can conflict with many
@@ -43,13 +43,13 @@ valid uris, such as the ones starting with prefixes like "mailto:", "git:",
 value of uri field, it considers the string to be a URI, unless it is a
 CURIE registered in the document. Case in point: if you define a CURIE with
 the prefix "data", you will stop otherwise legit URIs of the form "data:"
-to be parsed as URIs, in your Hyper message. At which point you may want to
+to be parsed as URIs, in your Hyper message. At such a point you may want to
 reconsider the prefix chosen. You can find the full list of possibly
 conflicting prefixes by looking at the [IANA URI Schemes
 Registry](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml#uri-schemes-1).
 
-**Important:** Hyper registers a special CURIE `{"prefix" : "h", "uri" :
-"http://hyperjson.io/props/"}` that is always present and cannot
+**Important:** Hyper registers a special CURIE `"h":
+"http://hyperjson.io/props/"` that is always present and cannot
 be removed or overriden.
 
 ##### Example use of h:head in a Hyper document:
@@ -61,7 +61,7 @@ be removed or overriden.
     "title": "Department Employees",
     "hreflang": "en",
     "profiles": ["ex:profiles/department-employees"],
-    "curies": [{"prefix": "ex", "href": "http://api.example.com/"}],
+    "curies": {"ex": "http://api.example.com/"},
   },
   "department" : {
     "name" : "North-East Region",

--- a/_includes/propdefs/head.md
+++ b/_includes/propdefs/head.md
@@ -34,18 +34,18 @@ definitions.
 
 ###### curies
 
-optional. Map of
-[CURIEs](https://www.w3.org/TR/2010/NOTE-curie-20101216/), complying to the
-W3C definition. In Hyper, CURIEs can be used in values of "uri" fields or
-as any object's key's name. Please note that CURIEs can conflict with many
-valid uris, such as the ones starting with prefixes like "mailto:", "git:",
-"urn:", "about:" etc. When Hyper sees a colon (":") in a key name or in a
-value of uri field, it considers the string to be a URI, unless it is a
-CURIE registered in the document. Case in point: if you define a CURIE with
-the prefix "data", you will stop otherwise legit URIs of the form "data:"
-to be parsed as URIs, in your Hyper message. At such a point you may want to
-reconsider the prefix chosen. You can find the full list of possibly
-conflicting prefixes by looking at the [IANA URI Schemes
+optional. A JSON object where keys are prefixes and values are URIs of
+corresponding [CURIEs](https://www.w3.org/TR/2010/NOTE-curie-20101216/),
+complying to the W3C definition. In Hyper, CURIEs can be used in values
+of "uri" fields or as any object's key's name. Please note that CURIEs
+can conflict with many valid uris, such as the ones starting with prefixes
+like "mailto:", "git:", "urn:", "about:" etc. When Hyper sees a colon (":")
+in a key name or in a value of uri field, it considers the string to be a
+URI, unless it is a CURIE registered in the document. Case in point: if you
+define a CURIE with the prefix "data", you will stop otherwise legit URIs
+of the form "data:" to be parsed as URIs, in your Hyper message. At such a
+point you may want to reconsider the prefix chosen. You can find the full
+list of possibly conflicting prefixes by looking at the [IANA URI Schemes
 Registry](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml#uri-schemes-1).
 
 **Important:** Hyper registers a special CURIE `"h":

--- a/_includes/propdefs/link.md
+++ b/_includes/propdefs/link.md
@@ -1,8 +1,10 @@
 h:link is a super-set of [h:ref](/spec#href) allowing representation of
 complex hyperlinks and parametrized actions (similar to HTML's Form element).
 
-h:link points to an array of objects, where each object can have following
-properties of predefined semantic meaning:
+h:link points to an array of objects, where the order of such links should
+not be considered significant.
+
+Each object can have following properties of predefined semantic meaning:
 
 ###### uri
 
@@ -39,11 +41,12 @@ can have following properties:
 
 ###### rel
 
-optional. array of link relation types per
+optional. An array of link relation types per
 [RFC8288](https://tools.ietf.org/html/rfc8288). Only IANA-registered link
 relation types SHOULD be refered to by simple names, all application-specific
 and non-common link relation types should be URIs (usually CURIEed, to save
-space).
+space).  The order of the link relations in this array should not be considerd
+significant.
 
 ###### label
 

--- a/_includes/propdefs/type.md
+++ b/_includes/propdefs/type.md
@@ -1,7 +1,7 @@
-An array of type indicators. a type indicator provides semantic information for
+An array of type indicators. A type indicator provides semantic information for
 the object in context. It is very similar to the `rel` attribute of `h:link`,
-but h:link indicates semantics of the linked element, whereas h:type indicates
+but h:link.rel indicates semantics of the linked element, whereas h:type indicates
 semantics of the object in the context.
 
-Just like in the case of `rels` you SHOULD only use standard types as simple
+Just like in the case of `rel` you SHOULD only use standard types as simple
 strings, all custom types should be indicated as CURIEd URIs.

--- a/_includes/propdefs/type.md
+++ b/_includes/propdefs/type.md
@@ -4,4 +4,5 @@ but h:link.rel indicates semantics of the linked element, whereas h:type indicat
 semantics of the object in the context.
 
 Just like in the case of `rel` you SHOULD only use standard types as simple
-strings, all custom types should be indicated as CURIEd URIs.
+strings, all custom types should be indicated as CURIEd URIs.  The order of
+these types should not be considered signficant.

--- a/_includes/samples/hal-hyper.json
+++ b/_includes/samples/hal-hyper.json
@@ -1,6 +1,6 @@
 {
   "h:head": {
-    "curies": [{"prefix": "ea", "uri": "http://example.com/docs/rels/"}]
+    "curies": {"ea": "http://example.com/docs/rels/"}
   },
   "h:ref": {"self": "/orders", "next": "/orders?page=2"},
   "h:link": [

--- a/_includes/samples/hyper-big-example.json
+++ b/_includes/samples/hyper-big-example.json
@@ -4,7 +4,7 @@
     "title": "Department Employees",
     "hreflang": "en",
     "profiles": ["ex:profiles/department-employees"],
-    "curies": [{"prefix": "ex", "href": "http://api.example.com/"}]
+    "curies": {"ex": "http://api.example.com/"}
   },
   "h:ref": {"self": "ex:users", "home": "ex:"},
   "h:link": [

--- a/_includes/samples/siren-hyper.json
+++ b/_includes/samples/siren-hyper.json
@@ -1,11 +1,8 @@
 {
   "head": {
-    "curies": [
-      {
-        "prefix": "siren-actions",
-        "uri": "https://github.com/kevinswiber/siren?fake-action="
+    "curies": {
+        "siren-actions": "https://github.com/kevinswiber/siren?fake-action="
       }
-    ]
   },
   "h:ref": {
     "self": "http://api.x.io/orders/42",

--- a/_includes/samples/uber-hyper.json
+++ b/_includes/samples/uber-hyper.json
@@ -1,6 +1,6 @@
 {
   "head": {
-    "curies": [{"prefix": "ex", "uri": "http://example.org/"}],
+    "curies": {"ex": "http://example.org/"},
     "profiles": ["ex:profiles/people-and-places"]
   },
   "h:ref": {"self": "ex:"},


### PR DESCRIPTION
clarify that arrays in Hyper are conceptually sets, contra `profiles`, which we are thinking of removing anyway in favor of HTTP headers.